### PR TITLE
connect: Support for specifying job prefix;

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -44,9 +44,10 @@ const getJob = async (jobId: string) => {
 
 vorpal
   .command("connect <queue> [url]", "connect to bull queue")
-  .action(async ({ queue: name, url = "redis://localhost:6379" }) => {
+  .option("-p, --prefix <prefix>", "prefix to use for all queue jobs")
+  .action(async ({ queue: name, url = "redis://localhost:6379", options }) => {
     queue && queue.close();
-    queue = Queue(name, url);
+    queue = Queue(name, url, options);
     await queue.isReady();
     console.log(chalk.green(`Connected to ${url}, queue: ${name}`));
     vorpal.delimiter(`BULL-REPL | ${name}> `).show();


### PR DESCRIPTION
Prior to this, it did not appear possible to use bull-repl with queues that used Bull's `prefix` option. This adds `-p, --prefix` as a option for the `connect` command to allow for connecting to queues that use a job prefix.