### PR TITLE
Add parameters to support connect over TLS

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,9 @@ export type ConnectParams = {
   options: {
     prefix?: string;
     redis?: string;
+    clientCert?: string;
+    clientKey?: string;
+    serverCert?: string;
   };
 };
 
@@ -73,4 +76,10 @@ export type LogsParams = {
 export type LogParams = {
   jobId: string;
   data: string;
+};
+
+export type RedisTLSOptions = {
+  clientKey: string;
+  clientCert: string;
+  serverCert: string;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { JobAdditional, Answer } from "./types";
+import { JobAdditional, Answer, RedisTLSOptions } from "./types";
 import { Job } from "bull";
 import { matchArray } from "searchjs";
 import chalk from "chalk";
@@ -6,6 +6,8 @@ import ms from "ms";
 import terminalLink from "terminal-link";
 import { getQueue } from "./queue";
 import Vorpal from "vorpal";
+import { readFile } from "fs";
+import { promisify } from "util";
 
 export const getJob = async (jobId: string) => {
   const queue = await getQueue();
@@ -129,4 +131,16 @@ export function wrapTryCatch(fn: Function) {
       return throwYellow(e.message);
     }
   };
+}
+
+export async function getRedisTLSOptions(opts: RedisTLSOptions) {
+  const promiseFs = promisify(readFile);
+
+  const [key, cert, ca] = await Promise.all([
+    promiseFs(opts.clientKey).then((bf: Buffer) => bf.toString()),
+    promiseFs(opts.clientCert).then((bf: Buffer) => bf.toString()),
+    promiseFs(opts.serverCert).then((bf: Buffer) => bf.toString())
+  ]);
+
+  return { tls: { key, cert, ca } };
 }


### PR DESCRIPTION
Add parameters to support connect over TLS.

This PR depends on https://github.com/OptimalBits/bull/pull/1563.

Usage example:
```shell
BULL-REPL>  connect queue -r redis://localhost:6379 -c ./certs/client-cert.pem -k ./certs/client-key.pem -s ./certs/server-cert.pem 
```