### PR TITLE
Add --uri, help examples, update bullmq, ioredis

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,15 @@
     {
       "type": "node",
       "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "attach",
       "name": "Debug bull-repl",
       "port": 9229
     }

--- a/index.ts
+++ b/index.ts
@@ -49,6 +49,7 @@ export const localStorage = (vorpal.localStorage as unknown) as WindowLocalStora
 vorpal
   .command("connect <queue>", "Connect to bull queue")
   .option("--prefix <prefix>", "Prefix to use for all queue jobs")
+  .option("-u, --uri <uri>", "Redis uri connection string")
   .option("-h, --host <host>", "Redis host for connection")
   .option("-p, --port <port>", "Redis port for connection")
   .option("-d, --db <db>", "Redis db for connection")

--- a/index.ts
+++ b/index.ts
@@ -47,26 +47,26 @@ export const localStorage = (vorpal.localStorage as unknown) as WindowLocalStora
 };
 
 vorpal
-  .command("connect <queue>", "connect to bull queue")
-  .option("--prefix <prefix>", "prefix to use for all queue jobs")
-  .option("-h, --host <host>", "redis host for connection")
-  .option("-p, --port <port>", "redis port for connection")
-  .option("-d, --db <db>", "redis db for connection")
-  .option("--password <password>", "redis password for connection")
-  .option("-c, --cert <cert>", "absolute path to pem certificate if TLS used")
+  .command("connect <queue>", "Connect to bull queue")
+  .option("--prefix <prefix>", "Prefix to use for all queue jobs")
+  .option("-h, --host <host>", "Redis host for connection")
+  .option("-p, --port <port>", "Redis port for connection")
+  .option("-d, --db <db>", "Redis db for connection")
+  .option("--password <password>", "Redis password for connection")
+  .option("-c, --cert <cert>", "Absolute path to pem certificate if TLS used")
   .action(
     wrapTryCatch(async (params: ConnectParams) => {
       await connectToQueue(params, vorpal);
     })
   );
 
-vorpal.command("connect-list", "list of saved connections").action(
+vorpal.command("connect-list", "List of saved connections").action(
   wrapTryCatch(async () => {
     console.table(localStorage._localStorage._keys);
   })
 );
 
-vorpal.command("connect-rm <name>", "remove saved connection").action(
+vorpal.command("connect-rm <name>", "Remove saved connection").action(
   wrapTryCatch(async ({ name }: { name: string }) => {
     if (name === LAST_SAVED_CONNECTION_NAME) {
       return logYellow(`Can't use reserved name, please use another`);
@@ -81,7 +81,7 @@ vorpal.command("connect-rm <name>", "remove saved connection").action(
   })
 );
 
-vorpal.command("connect-save <name>", "save current connection").action(
+vorpal.command("connect-save <name>", "Save current connection").action(
   wrapTryCatch(async ({ name: nameForSave }: { name: string }) => {
     if (nameForSave === LAST_SAVED_CONNECTION_NAME) {
       return logYellow(`Can't use reserved name, please use another`);
@@ -95,7 +95,7 @@ vorpal.command("connect-save <name>", "save current connection").action(
   })
 );
 
-vorpal.command("connect-to <name>", "connect to saved connection").action(
+vorpal.command("connect-to <name>", "Connect to saved connection").action(
   wrapTryCatch(async ({ name: connectToName }: { name: string }) => {
     const savedItem = localStorage.getItem(connectToName);
     if (!savedItem) {
@@ -106,7 +106,7 @@ vorpal.command("connect-to <name>", "connect to saved connection").action(
   })
 );
 
-vorpal.command("stats", "count of jobs by groups").action(
+vorpal.command("stats", "Count of jobs by type").action(
   wrapTryCatch(async () => {
     const queue = await getQueue();
     const counts = await queue.getJobCounts(
@@ -123,11 +123,11 @@ vorpal.command("stats", "count of jobs by groups").action(
 );
 
 vorpal
-  .command("active", "fetch active jobs")
-  .option("-f, --filter <filter>", `filter jobs via ${searchjsLink}`)
-  .option("-t, --timeAgo <timeAgo>", `get jobs since time ago via ${msLink}`)
-  .option("-s, --start <start>", "start index (pagination)")
-  .option("-e, --end <end>", "end index (pagination)")
+  .command("active", "Fetch active jobs")
+  .option("-f, --filter <filter>", `Filter jobs via ${searchjsLink}`)
+  .option("-t, --timeAgo <timeAgo>", `Get jobs since time ago via ${msLink}`)
+  .option("-s, --start <start>", "Start index (pagination)")
+  .option("-e, --end <end>", "End index (pagination)")
   .action(
     wrapTryCatch(async ({ options }: ActiveParams) => {
       const queue = await getQueue();
@@ -141,11 +141,11 @@ vorpal
   );
 
 vorpal
-  .command("waiting", "fetch waiting jobs")
-  .option("-f, --filter <filter>", `filter jobs via ${searchjsLink}`)
-  .option("-t, --timeAgo <timeAgo>", `get jobs since time ago via ${msLink}`)
-  .option("-s, --start <start>", "start index (pagination)")
-  .option("-e, --end <end>", "end index (pagination)")
+  .command("waiting", "Fetch waiting jobs")
+  .option("-f, --filter <filter>", `Filter jobs via ${searchjsLink}`)
+  .option("-t, --timeAgo <timeAgo>", `Get jobs since time ago via ${msLink}`)
+  .option("-s, --start <start>", "Start index (pagination)")
+  .option("-e, --end <end>", "End index (pagination)")
   .action(
     wrapTryCatch(async ({ options }: WaitingParams) => {
       const queue = await getQueue();
@@ -159,11 +159,11 @@ vorpal
   );
 
 vorpal
-  .command("completed", "fetch completed jobs")
-  .option("-f, --filter <filter>", `filter jobs via ${searchjsLink}`)
-  .option("-t, --timeAgo <timeAgo>", `get jobs since time ago via ${msLink}`)
-  .option("-s, --start <start>", "start index (pagination)")
-  .option("-e, --end <end>", "end index (pagination)")
+  .command("completed", "Fetch completed jobs")
+  .option("-f, --filter <filter>", `Filter jobs via ${searchjsLink}`)
+  .option("-t, --timeAgo <timeAgo>", `Get jobs since time ago via ${msLink}`)
+  .option("-s, --start <start>", "Start index (pagination)")
+  .option("-e, --end <end>", "End index (pagination)")
   .action(
     wrapTryCatch(async ({ options }: CompletedParams) => {
       const queue = await getQueue();
@@ -177,11 +177,11 @@ vorpal
   );
 
 vorpal
-  .command("failed", "fetch failed jobs")
-  .option("-f, --filter <filter>", `filter jobs via ${searchjsLink}`)
-  .option("-t, --timeAgo <timeAgo>", `get jobs since time ago via ${msLink}`)
-  .option("-s, --start <start>", "start index (pagination)")
-  .option("-e, --end <end>", "end index (pagination)")
+  .command("failed", "Fetch failed jobs")
+  .option("-f, --filter <filter>", `Filter jobs via ${searchjsLink}`)
+  .option("-t, --timeAgo <timeAgo>", `Get jobs since time ago via ${msLink}`)
+  .option("-s, --start <start>", "Start index (pagination)")
+  .option("-e, --end <end>", "End index (pagination)")
   .action(
     wrapTryCatch(async ({ options }: FailedParams) => {
       const queue = await getQueue();
@@ -195,7 +195,7 @@ vorpal
   );
 
 vorpal
-  .command("delayed", "fetch delayed jobs")
+  .command("delayed", "Fetch delayed jobs")
   .option("-f, --filter <filter>", `filter jobs via ${searchjsLink}`)
   .option("-t, --timeAgo <timeAgo>", `get jobs since time ago via ${msLink}`)
   .option("-s, --start <start>", "start index (pagination)")
@@ -212,7 +212,7 @@ vorpal
     })
   );
 
-vorpal.command("pause", "pause current queue").action(
+vorpal.command("pause", "Pause current queue").action(
   wrapTryCatch(async () => {
     const queue = await getQueue();
     await answer(vorpal, "Pause queue");
@@ -221,7 +221,7 @@ vorpal.command("pause", "pause current queue").action(
   })
 );
 
-vorpal.command("resume", "resume current queue from pause").action(
+vorpal.command("resume", "Resume current queue from pause").action(
   wrapTryCatch(async () => {
     const queue = await getQueue();
     await answer(vorpal, "Resume queue");
@@ -230,7 +230,7 @@ vorpal.command("resume", "resume current queue from pause").action(
   })
 );
 
-vorpal.command("get <jobId...>", "get job").action(
+vorpal.command("get <jobId...>", "Get job").action(
   wrapTryCatch(async ({ jobId }: GetParams) => {
     const { notFoundIds, foundJobs } = await splitJobsByFound(jobId);
     notFoundIds.length && logYellow(`Not found jobs: ${notFoundIds}`);
@@ -239,7 +239,7 @@ vorpal.command("get <jobId...>", "get job").action(
 );
 
 vorpal
-  .command("add <data>", "add job to queue")
+  .command("add <data>", "Add job to queue e.g. add '{\"x\": 1}'")
   .option("-n, --name <name>", "name for named job")
   .action(
     wrapTryCatch(async function({ data, options }: AddParams) {
@@ -248,7 +248,7 @@ vorpal
       try {
         jobData = JSON.parse(data);
       } catch (e) {
-        return throwYellow(`Error occured, seems "data" incorrect json`);
+        return throwYellow(`Error: Argument <data> is invalid: ${e}`);
       }
       await answer(vorpal, "Add");
       const jobName: string = options.name || "__default__";
@@ -259,7 +259,7 @@ vorpal
     })
   );
 
-vorpal.command("rm <jobId...>", "remove job").action(
+vorpal.command("rm <jobId...>", "Remove job").action(
   wrapTryCatch(async function({ jobId }: RmParams) {
     await answer(vorpal, "Remove");
     const { notFoundIds, foundJobs } = await splitJobsByFound(jobId);
@@ -269,7 +269,7 @@ vorpal.command("rm <jobId...>", "remove job").action(
   })
 );
 
-vorpal.command("retry <jobId...>", "retry job").action(
+vorpal.command("retry <jobId...>", "Retry job").action(
   wrapTryCatch(async function({ jobId }: RetryParams) {
     await answer(vorpal, "Retry");
     const { notFoundIds, foundJobs } = await splitJobsByFound(jobId);
@@ -279,7 +279,7 @@ vorpal.command("retry <jobId...>", "retry job").action(
   })
 );
 
-vorpal.command("retry-failed", "retry first 100 failed jobs").action(
+vorpal.command("retry-failed", "Retry first 100 failed jobs").action(
   wrapTryCatch(async function() {
     const queue = await getQueue();
     await answer(vorpal, "Retry failed jobs");
@@ -289,7 +289,7 @@ vorpal.command("retry-failed", "retry first 100 failed jobs").action(
   })
 );
 
-vorpal.command("promote <jobId...>", "promote job").action(
+vorpal.command("promote <jobId...>", "Promote job").action(
   wrapTryCatch(async function({ jobId }: PromoteParams) {
     await answer(vorpal, "Promote");
     const { notFoundIds, foundJobs } = await splitJobsByFound(jobId);
@@ -299,7 +299,7 @@ vorpal.command("promote <jobId...>", "promote job").action(
   })
 );
 
-vorpal.command("fail <jobId> <reason>", "fail job").action(
+vorpal.command("fail <jobId> <reason>", "Move job to failed").action(
   wrapTryCatch(async function({ jobId, reason }: FailParams) {
     await getQueue();
     const job = await getJob(jobId);
@@ -310,20 +310,21 @@ vorpal.command("fail <jobId> <reason>", "fail job").action(
   })
 );
 
-vorpal.command("complete <jobId> <data>", "complete job").action(
-  wrapTryCatch(async function({ jobId, data }: CompleteParams) {
-    await getQueue();
-    const job = await getJob(jobId);
-    let returnValue: string;
-    try {
-      returnValue = JSON.parse(data);
-    } catch (e) {
-      return throwYellow(`Error occured, seems "data" incorrect json`);
-    }
-    await answer(vorpal, "Complete");
-    await job.moveToCompleted(returnValue, "0");
-    logGreen(`Job "${jobId}" completed`);
-  })
+vorpal.command("complete <jobId> <data>", "Move job to completed e.g. complete 1 '{\"x\": 1}'")
+  .action(
+    wrapTryCatch(async function({ jobId, data }: CompleteParams) {
+      await getQueue();
+      const job = await getJob(jobId);
+      let returnValue: string;
+      try {
+        returnValue = JSON.parse(data);
+      } catch (e) {
+        return throwYellow(`Error: Argument <data> is invalid: ${e}`);
+      }
+      await answer(vorpal, "Complete");
+      await job.moveToCompleted(returnValue, "0");
+      logGreen(`Job "${jobId}" completed`);
+    })
 );
 
 vorpal
@@ -341,6 +342,7 @@ vorpal
   )
   .action(
     wrapTryCatch(async function({ period, options }: CleanParams) {
+      const types = ["completed", "wait", "active", "delayed", "failed"];
       const queue = await getQueue();
       const grace = period && period.length ? ms(period as string) : void 0;
       if (!grace) {
@@ -348,10 +350,10 @@ vorpal
       }
       const status = options.status || "completed";
       if (
-        !["completed", "wait", "active", "delayed", "failed"].includes(status)
+        !types.includes(status)
       ) {
         return throwYellow(
-          "Incorrect status, should be: completed or wait or active or delayed or failed"
+          `Unknown status, must be one of: ${types.join(", ")}`
         );
       }
       await answer(vorpal, "Clean");
@@ -364,7 +366,7 @@ vorpal
   );
 
 vorpal
-  .command("logs <jobId>", "get logs of job")
+  .command("logs <jobId>", "Get logs of job")
   .option("-s, --start <start>", "Start of logs")
   .option("-e, --end <end>", "End of logs")
   .action(
@@ -383,7 +385,7 @@ vorpal
     })
   );
 
-vorpal.command("log <jobId> <data>", "add log to job").action(
+vorpal.command("log <jobId> <data>", "Add log to job").action(
   wrapTryCatch(async function({ jobId, data }: LogParams) {
     await getQueue();
     const job = await getJob(jobId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,9 +325,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/ioredis": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.16.1.tgz",
-      "integrity": "sha512-3O4gHSxQ4C0AhJVHIW4TFYsv0OqORLmiu5mgceciJrPct/ToTwRehroLU3vw5evzQgemdKx05dU6nKs5bCN1bQ==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.16.7.tgz",
+      "integrity": "sha512-gc0g0OlBxc/Mlhutv5Njkm3A4m5oZXq8gCeEGOt2c4p4ZIYw9dotYjg6z8nSsxOH9KnKkjWUzg0oGCAqtnGFIg==",
       "requires": {
         "@types/node": "*"
       }
@@ -413,9 +413,9 @@
       "dev": true
     },
     "bullmq": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-1.8.7.tgz",
-      "integrity": "sha512-iaI1Kl3j9hXTEXVfuFV9cnYOW6LTBumPvr1WPz7WLsYWk4FqIWjU4fo+S9Ufz/MM35BgQfEAAYMGsXBuk2GNfA==",
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-1.8.13.tgz",
+      "integrity": "sha512-WEYuI2I4X5gmtKA00s9wrrMzgaZCcwYXFAuGP0Zb+sc3YQvKRhNnXX+K1ikaeb14K+CaFLjojry7hPNVyITwhw==",
       "requires": {
         "@types/ioredis": "^4.0.13",
         "cron-parser": "^2.7.3",
@@ -471,12 +471,12 @@
       "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
     },
     "cron-parser": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.13.0.tgz",
-      "integrity": "sha512-UWeIpnRb0eyoWPVk+pD3TDpNx3KCFQeezO224oJIkktBrcW6RoAPOx5zIKprZGfk6vcYSmA8yQXItejSaDBhbQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.15.0.tgz",
+      "integrity": "sha512-rMFkrQw8+oG5OuwjiXesup4KeIlEG/IU82YtG4xyAHbO5jhKmYaHPp/ZNhq9+7TjSJ65E3zV3kQPUbmXSff2/g==",
       "requires": {
-        "is-nan": "^1.2.1",
-        "moment-timezone": "^0.5.25"
+        "is-nan": "^1.3.0",
+        "moment-timezone": "^0.5.31"
       }
     },
     "debug": {
@@ -596,9 +596,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.16.3.tgz",
-      "integrity": "sha512-Ejvcs2yW19Vq8AipvbtfcX3Ig8XG9EAyFOvGbhI/Q1QoVOK9ZdgY092kdOyOWIYBnPHjfjMJhU9qhsnp0i0K1w==",
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.17.3.tgz",
+      "integrity": "sha512-iRvq4BOYzNFkDnSyhx7cmJNOi1x/HWYe+A4VXHBu4qpwJaGT1Mp+D2bVGJntH9K/Z/GeOM/Nprb8gB3bmitz1Q==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.1.1",
@@ -670,14 +670,14 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "moment": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "moment-timezone": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   ],
   "dependencies": {
     "@moleculer/vorpal": "1.11.5",
-    "bullmq": "1.8.7",
+    "bullmq": "1.8.13",
     "chalk": "4.0.0",
-    "ioredis": "4.16.3",
+    "ioredis": "4.17.3",
     "ms": "2.1.2",
     "searchjs": "1.0.2",
     "terminal-link": "2.1.1"

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -18,10 +18,10 @@ export async function getQueue() {
 export async function setQueue(
   name: string,
   prefix: string,
-  options: IORedis.RedisOptions
+  options: string|IORedis.RedisOptions
 ) {
   queue && (await queue.close());
-  const client = new IORedis(options);
+  const client = new IORedis(options as any);
   queue = new Queue(name, { connection: client, ...{ prefix } });
   await queue.waitUntilReady();
   return queue;
@@ -42,7 +42,7 @@ export async function connectToQueue(
         rejectUnauthorized: false
       }
     : void 0;
-  await setQueue(name, prefix, {
+  await setQueue(name, prefix, options.uri || {
     host,
     port,
     db,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,9 @@ export type Answer = {
 
 export type ConnectParams = {
   queue: string;
-  options: {
+  options: {    
     prefix?: string;
+    uri?: string;
     host?: string;
     port?: number;
     db?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,7 +47,7 @@ export const getFilter = (filter?: string) => {
     try {
       resolve(JSON.parse(filter || "{}"));
     } catch (e) {
-      throwYellow(`Error occured, seems passed "filter" incorrect json`);
+      throwYellow(`Error: Argument to --filter is invalid: ${e}`);
     }
   });
 };
@@ -59,7 +59,7 @@ export const getTimeAgoFilter = (timeAgo?: string) => {
       const filter = msAgo ? { timestamp: { gte: Date.now() - msAgo } } : {};
       resolve(filter);
     } catch (e) {
-      throwYellow(`Error occured, seems passed "timeAgo" incorrect`);
+      throwYellow(`Error: Argument to --timeAgo is invalid: ${e}`);
     }
   });
 };
@@ -70,6 +70,7 @@ export const logArray = (arr: Array<unknown>) => {
     depth: null,
     maxArrayLength: Infinity
   });
+  console.log(`count: ${chalk.yellow(arr.length)}`)
 };
 
 export const searchjsLink = terminalLink(


### PR DESCRIPTION
- Adds simple JSON examples in help output for `add` and `complete`
- Output the exception message on JSON parse errors
- Output `count` for array logging operations
- Uppercase command description sentences to match vorpal output
- Add `--uri` redis connection string option (this may have been there before?...easier for remote bash scripting from existing env vars that use redis:// strings
- Update bullmq, ioredis