### PR TITLE
feat: retry failed jobs with number option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import type {
   AddParams,
   RmParams,
   RetryParams,
+  RetryFailedParams,
   PromoteParams,
   FailParams,
   CompleteParams,
@@ -336,14 +337,18 @@ vorpal
 vorpal
   .command("retry-failed", "Retry first 100 failed jobs")
   .option(
+    "-n, --number <number>",
+    "Number of failed jobs. default: 100"
+  )
+  .option(
     "-y, --yes",
     "Skip answer validation"
   )
   .action(
-    wrapTryCatch(async function({ options }: YesParams) {
+    wrapTryCatch(async function({ options }: RetryFailedParams) {
       const queue = await getQueue();
       await answer(vorpal, "Retry failed jobs", options.yes);
-      const failedJobs = await queue.getFailed(0, 100);
+      const failedJobs = await queue.getFailed(0, options.number || 100);
       await Promise.all(failedJobs.map(j => j.retry()));
       logGreen("All failed jobs retried");
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,14 @@ export type AddParams = {
 
 export type RmParams = GetParams;
 export type RetryParams = GetParams;
+
+export type RetryFailedParams = {
+  options: {
+    number?: number;
+    yes?: boolean;
+  }
+}
+
 export type PromoteParams = GetParams;
 
 export type FailParams = {


### PR DESCRIPTION
Feat: adding number option for retry failed command
example:
```
retry-failed -n 300 -y
```