### PR TITLE
feat: exec commands from file

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type ConnectParams = {
     port?: number;
     db?: number;
     exec?: string;
+    execFile?: string;
     url?: string;
     password?: string;
     cert?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import readline from 'readline';
 import type { JobAdditional, Answer } from "./types";
 import type { Job } from "bull";
 import { run } from "node-jq";
@@ -114,6 +116,17 @@ export async function splitJobsByFound(jobIds: string[]) {
     i++;
   }
   return { notFoundIds, foundJobs };
+}
+
+export function readLines(file: string) {
+  const fileStream = fs.createReadStream(file);
+
+  const rl = readline.createInterface({
+    input: fileStream,
+    crlfDelay: Infinity
+  });
+
+  return rl;
 }
 
 export function wrapTryCatch(fn: Function) {


### PR DESCRIPTION
Feat: exec commands from file
example:
`commands.txt`
```
add '{"x":1}' -y
add '{"x":2}' -y
```
import
```
bull-repl connect -f commands.txt
```